### PR TITLE
add exported getter for requestIDHeader

### DIFF
--- a/http.go
+++ b/http.go
@@ -37,6 +37,11 @@ func init() {
 	}
 }
 
+// RequestIDHeader provides the name of the request tracking header
+func RequestIDHeader() string {
+	return requestIDHeader
+}
+
 // HTTPServer is a wrapper for http.Server.
 //
 // This struct overrides Serve and ListenAndServe* methods.


### PR DESCRIPTION
This makes the tracking header name available for programs using well, to help ensure consistency in the choice of header names.