### PR TITLE
Sleep before context cancellation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run: go vet .
       - run: |
           go build ./test/restart
-          ./restart
+          CANCELLATION_DELAY_SECONDS=0 ./restart
       - run: |
           cd ./test/spf13
           cp main.go_ main.go

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Commands using this framework implement these external specifications:
 
     This is used internally for graceful restart.
 
+* `CANCELLATION_DELAY_SECONDS`
+
+    After `SIGINT` or `SIGTERM` received, the signal handler waits for the seconds before cancelling the context.
+    The default value is 5 sec.
+
 Usage
 -----
 

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/spf13/viper v1.3.2
 	golang.org/x/net v0.0.0-20190921015927-1a5e07d1ff72
 )
+
+go 1.13

--- a/graceful_unix.go
+++ b/graceful_unix.go
@@ -198,7 +198,8 @@ RESTART:
 
 func (g *Graceful) makeChild(files []*os.File) *exec.Cmd {
 	child := exec.Command(os.Args[0], os.Args[1:]...)
-	child.Env = []string{listenEnv + "=" + strconv.Itoa(len(files))}
+	child.Env = os.Environ()
+	child.Env = append(child.Env, listenEnv+"="+strconv.Itoa(len(files)))
 	child.ExtraFiles = files
 	return child
 }

--- a/signal.go
+++ b/signal.go
@@ -31,10 +31,11 @@ func handleSignal(env *Environment) {
 
 	go func() {
 		s := <-ch
+		delay := getDelaySecondsFromEnv()
 		log.Warn("well: got signal", map[string]interface{}{
 			"signal": s.String(),
+			"delay":  delay,
 		})
-		delay := getDelaySecondsFromEnv()
 		time.Sleep(time.Duration(delay) * time.Second)
 		env.Cancel(errSignaled)
 	}()

--- a/signal.go
+++ b/signal.go
@@ -42,7 +42,7 @@ func handleSignal(env *Environment) {
 
 func getDelaySecondsFromEnv() int {
 	delayStr := os.Getenv(cancellationDelaySecondsEnv)
-	if len(delayStr) <= 0 {
+	if len(delayStr) == 0 {
 		return defaultCancellationDelaySeconds
 	}
 
@@ -57,9 +57,8 @@ func getDelaySecondsFromEnv() int {
 	}
 	if delay < 0 {
 		log.Warn("well: round up negative cancellation delay seconds to 0s", map[string]interface{}{
-			"env":       delayStr,
-			"delay":     0,
-			log.FnError: err,
+			"env":   delayStr,
+			"delay": 0,
 		})
 		return 0
 	}

--- a/test/restart/main.go
+++ b/test/restart/main.go
@@ -136,7 +136,7 @@ func ping(network, addr string) error {
 	}
 	if string(data) != "hello 1" {
 		log.Error("wrong response", map[string]interface{}{
-			"data": data,
+			"data": string(data),
 		})
 		return errors.New("invalid response")
 	}
@@ -144,7 +144,7 @@ func ping(network, addr string) error {
 		"data": string(data),
 	})
 
-	if time.Since(st) > 6*time.Second {
+	if time.Since(st) > time.Second {
 		return errors.New("too long")
 	}
 	return nil

--- a/test/restart/main.go
+++ b/test/restart/main.go
@@ -144,7 +144,7 @@ func ping(network, addr string) error {
 		"data": string(data),
 	})
 
-	if time.Since(st) > time.Second {
+	if time.Since(st) > 6*time.Second {
 		return errors.New("too long")
 	}
 	return nil


### PR DESCRIPTION
To shutdown a k8s Pod gracefully, the container should be terminated after Endpoint deletion.
https://github.com/cybozu-go/neco/issues/661

In this PR, the following 2 changes are mainly made:
- The signal handler has been changed to sleep some seconds(default: 5s) after receiving SIGTERM to make containers shutdown gracefully.
- Graceful restart servers inherit environment variables to child processes.