### PR TITLE
Add deprecation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 Go Command Framework
 ====================
 
+**Deprecated: This project has come to an end and will not receive any update.**
+
 This is a framework to create well-behaving commands.
 
 Features

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,9 @@
 /*
-Package well provides a framework that helps implementation of
-commands having these features:
+Package well provides a framework that helps implementation of commands.
+
+Deprecated: This project has come to an end and will not receive any update.
+
+Features:
 
 Better logging:
 


### PR DESCRIPTION
As well as cybozu-go/log, we don't have plan for future updates.
Let's deprecate this together.
ref: https://github.com/cybozu-go/log/issues/47